### PR TITLE
divide Sproutvideo::Video.signed_embed_code for convinience

### DIFF
--- a/lib/sproutvideo/video.rb
+++ b/lib/sproutvideo/video.rb
@@ -29,6 +29,11 @@ module Sproutvideo
     def self.signed_embed_code(video_id, params={}, expires=nil, protocol='http')
       #get video
       resp = get("/videos/#{video_id}")
+      generate_signed_embed_code(resp, params, expires, protocol)
+    end
+
+    def self.generate_signed_embed_code(resp, params={}, expires=nil, protocol='http')
+      video_id = resp.body[:id] 
       token = resp.body[:security_token]
       
       host = 'videos.sproutvideo.com'


### PR DESCRIPTION
Sproutvideo::Video.signed_embed_code is very useful.

But if I want to get both HD and SD video signed url, 
I do not want to use the method to reduce API call.
Because Sproutvide API has a rate limit at 100 requests per minute. 

Sproutvideo::Video.signed_embed_code() is called get single video API in it, so we need to call API twice at one transaction.

So, I want to divide the method into two method. We can generate many signed embed code, but only one API call is needed.
