### PR TITLE
Unpin rest-client to use v2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rest-client", '~> 1.8.0'
+gem "rest-client"
 gem 'json', '~> 1.8.6'
 gem "multi_json"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,18 +4,22 @@ GEM
     diff-lcs (1.1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (1.8.6)
-    mime-types (2.99.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     multi_json (1.14.1)
     netrc (0.11.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    rest-client (1.8.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -26,7 +30,7 @@ GEM
     rspec-mocks (2.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
 
 PLATFORMS
   ruby
@@ -35,7 +39,7 @@ DEPENDENCIES
   json (~> 1.8.6)
   multi_json
   rdoc (~> 3.12.1)
-  rest-client (~> 1.8.0)
+  rest-client
   rspec (~> 2.8.0)
 
 BUNDLED WITH

--- a/sproutvideo-rb.gemspec
+++ b/sproutvideo-rb.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.8.0"])
+      s.add_runtime_dependency(%q<rest-client>, [">= 2"])
       s.add_runtime_dependency(%q<json>, ["~> 1.8.6"])
       s.add_runtime_dependency(%q<multi_json>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.8.0"])
@@ -75,7 +75,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rdoc>, ["~> 3.12.1"])
     end
   else
-    s.add_dependency(%q<rest-client>, ["~> 1.8.0"])
+    s.add_dependency(%q<rest-client>, [">= 2"])
     s.add_dependency(%q<json>, ["~> 1.8.6"])
     s.add_dependency(%q<multi_json>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.8.0"])


### PR DESCRIPTION
The update to v1.7.0 of sproutvideo-rb pinned the rest-client gem at 1.8.0, which results in [this error](https://github.com/rest-client/rest-client/issues/612). Bumping up rest-client seems to fix the issue.